### PR TITLE
Call flush() before closing the LD client

### DIFF
--- a/run_conversion_experiments.py
+++ b/run_conversion_experiments.py
@@ -89,6 +89,7 @@ callLD()
 
 
 '''
-Responsibly close the LD Client
+Flush any pending analytics events & the responsibly close the LD Client
 '''
+ldclient.get().flush()
 ldclient.get().close()


### PR DESCRIPTION
This is to prevent event loss for the experiment results page as discussed here: https://launchdarkly.slack.com/archives/CNRDHSW3A/p1669284739184149

(Leaving out the fact that the behavior of the close() method is somewhat unexpected for both I and Tom.)